### PR TITLE
chore: adopt cookiecutter-scverse v0.7.0 + pre-commit autoupdate

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec",
-  "checkout": "v0.6.0",
+  "commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95",
+  "checkout": "v0.7.0",
   "context": {
     "cookiecutter": {
       "project_name": "slurm_sweep",
@@ -36,7 +36,7 @@
         "trim_blocks": true
       },
       "_template": "https://github.com/scverse/cookiecutter-scverse",
-      "_commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec"
+      "_commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95"
     }
   },
   "directory": null

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report something that is broken or incorrect
-labels: bug
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -9,8 +9,7 @@ body:
         detailing how to provide the necessary information for us to reproduce your bug. In brief:
           * Please provide exact steps how to reproduce the bug in a clean Python environment.
           * In case it's not clear what's causing this bug, please provide the data or the data generation procedure.
-          * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly
-            available datasets or to share a subset of your data.
+          * Replicate problems on public datasets or share data subsets when full sharing isn't possible.
 
   - type: textarea
     id: report

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature for slurm_sweep
-labels: enhancement
+type: Enhancement
 body:
   - type: textarea
     id: description

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,23 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Check package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   release:
     types: [published]
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 # Use "trusted publishing", see https://docs.pypi.org/trusted-publishers/
 jobs:
   release:
@@ -20,14 +15,12 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 jobs:
   # Get the test environment from hatch as defined in pyproject.toml.
   # This ensures that the pyproject.toml is the single point of truth for test definitions and the same tests are
@@ -28,12 +23,12 @@ jobs:
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Get test environments
         id: get-envs
         run: |
@@ -62,15 +57,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.env.python }}
-          cache-dependency-glob: pyproject.toml
       - name: create hatch environment
         run: uvx hatch env create ${{ matrix.env.name }}
       - name: run tests using hatch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,16 @@ default_stages:
 minimum_pre_commit_version: 2.16.0
 repos:
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.3.10
+    rev: v2.4.13
     hooks:
       - id: biome-format
         exclude: ^\.cruft\.json$ # inconsistent indentation with cruft - file never to be modified manually.
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.11.1
+    rev: v2.21.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.12
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
+    nodejs: latest
   jobs:
     create_environment:
       - asdf plugin add uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,89 +23,72 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "numpy",
   # for debug logging (referenced from the issue template)
   "session-info2",
   "simple-slurm",
   "typer",
   "wandb",
 ]
-optional-dependencies.dev = [
+optional-dependencies.examples = [
+  "scembed",
+]
+# https://docs.pypi.org/project_metadata/#project-urls
+urls.Documentation = "https://github.com/quadbio/slurm_sweep"
+urls.Homepage = "https://github.com/quadbio/slurm_sweep"
+urls.Source = "https://github.com/quadbio/slurm_sweep"
+scripts.slurm-sweep = "slurm_sweep.main:app"  # Add entry point for the CLI
+
+[dependency-groups]
+dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-optional-dependencies.doc = [
-  "docutils>=0.8,!=0.18.*,!=0.19.*",
+test = [
+  "coverage>=7.10",
+  "pytest",
+  "pytest-cov",     # For VS Code’s coverage functionality
+]
+doc = [
   "ipykernel",
   "ipython",
   "myst-nb>=1.1",
   "pandas",
-  # Until pybtex >0.24.0 releases: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
-  "setuptools",
   "sphinx>=8.1",
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",
   "sphinx-copybutton",
   "sphinx-tabs",
   "sphinxcontrib-bibtex>=1",
+  "sphinxcontrib-katex",
   "sphinxext-opengraph",
 ]
-optional-dependencies.examples = [
-  "scembed",
+
+[tool.hatch]
+envs.default.installer = "uv"
+envs.default.dependency-groups = [ "dev" ]
+envs.docs.dependency-groups = [ "doc" ]
+envs.docs.scripts.build = "sphinx-build -M html docs docs/_build {args}"
+envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
+envs.docs.scripts.clean = "git clean -fdX -- {args:docs}"
+envs.hatch-test.dependency-groups = [ "dev", "test" ]
+envs.hatch-test.matrix = [
+  # Test the lowest and highest supported Python versions with normal deps
+  { deps = [ "stable" ], python = [ "3.11", "3.14" ] },
+  # Test the newest supported Python version also with pre-release deps
+  { deps = [ "pre" ], python = [ "3.14" ] },
 ]
-optional-dependencies.test = [
-  "coverage>=7.10",
-  "pytest",
-  "pytest-cov",     # For VS Code’s coverage functionality
-]
-
-# https://docs.pypi.org/project_metadata/#project-urls
-urls.Documentation = "https://github.com/quadbio/slurm_sweep"
-urls.Homepage = "https://github.com/quadbio/slurm_sweep"
-urls.Source = "https://github.com/quadbio/slurm_sweep"
-
-scripts.slurm-sweep = "slurm_sweep.main:app" # Add entry point for the CLI
-
-[tool.hatch.version]
-source = "vcs"
-
-[tool.hatch.envs.default]
-installer = "uv"
-features = [ "dev" ]
-
-[tool.hatch.envs.docs]
-features = [ "doc" ]
-scripts.build = "sphinx-build -M html docs docs/_build {args}"
-scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
-scripts.clean = "git clean -fdX -- {args:docs}"
-
-# Test the lowest and highest supported Python versions with normal deps
-[[tool.hatch.envs.hatch-test.matrix]]
-deps = [ "stable" ]
-python = [ "3.11", "3.13" ]
-
-# Test the newest supported Python version also with pre-release deps
-[[tool.hatch.envs.hatch-test.matrix]]
-deps = [ "pre" ]
-python = [ "3.13" ]
-
-[tool.hatch.envs.hatch-test]
-features = [ "dev", "test" ]
-
-[tool.hatch.envs.hatch-test.overrides]
 # If the matrix variable `deps` is set to "pre",
 # set the environment variable `UV_PRERELEASE` to "allow".
-matrix.deps.env-vars = [
+envs.hatch-test.overrides.matrix.deps.env-vars = [
   { key = "UV_PRERELEASE", value = "allow", if = [ "pre" ] },
 ]
+version.source = "vcs"
 
 [tool.ruff]
 line-length = 120
 src = [ "src" ]
 extend-include = [ "*.ipynb" ]
-
 format.docstring-code-format = true
-
 lint.select = [
   "B",      # flake8-bugbear
   "BLE",    # flake8-blind-except
@@ -138,19 +121,19 @@ lint.per-file-ignores."*/__init__.py" = [ "F401" ]
 lint.per-file-ignores."tests/*" = [ "D" ]
 lint.pydocstyle.convention = "numpy"
 
-[tool.pytest.ini_options]
-testpaths = [ "tests" ]
-xfail_strict = true
-addopts = [
+[tool.pytest]
+ini_options.testpaths = [ "tests" ]
+ini_options.xfail_strict = true
+ini_options.addopts = [
   "--import-mode=importlib", # allow using test files with same name
 ]
 
-[tool.coverage.run]
-source = [ "slurm_sweep" ]
-patch = [ "subprocess" ]
-omit = [
+[tool.coverage]
+run.omit = [
   "**/test_*.py",
 ]
+run.patch = [ "subprocess" ]
+run.source = [ "slurm_sweep" ]
 
 [tool.cruft]
 skip = [


### PR DESCRIPTION
## Summary

Adopts the parts of the cookiecutter-scverse v0.7.0 template update ([#22](https://github.com/quadbio/slurm_sweep/pull/22)) that are relevant to this repo, and folds in the pre-commit autoupdate from [#23](https://github.com/quadbio/slurm_sweep/pull/23). Codecov-related template changes are intentionally **not** adopted — current setup is kept as-is.

## Changes

### Template / CI bumps
- `actions/checkout@v4` → `v5`, `astral-sh/setup-uv@v5` → `v7` across all workflows.
- Drop the `defaults: shell: bash -euo pipefail` block (now baked into `setup-uv`).
- Drop `cache-dependency-glob: pyproject.toml` (default behavior in `setup-uv@v7`).
- Issue templates: `labels:` → `type:` (`Bug`, `Enhancement`).
- `.cruft.json` bumped to commit `6ff5b92` / `v0.7.0`.
- `.readthedocs.yaml`: python `3.12` → `3.13`, add `nodejs: latest`.

### `pyproject.toml`
- Migrate `[project.optional-dependencies]` `dev`/`doc`/`test` to `[dependency-groups]`. Keep `optional-dependencies.examples` (depends on `scembed`) for `pip install slurm_sweep[examples]`.
- Switch hatch envs from `features = […]` to `dependency-groups = […]`.
- Drop `numpy` from runtime deps — not imported anywhere in `src/`, no historical pinning rationale.
- Drop `docutils` and `setuptools` from the doc group; add `sphinxcontrib-katex`.
- Test matrix: stable `["3.11", "3.13"]` → `["3.11", "3.14"]`; pre `["3.13"]` → `["3.14"]`.
- Reformatting from `pyproject-fmt v2.21.1` (collapsed `[tool.hatch]` subtables, etc.).

### Pre-commit (#23)
- `biome` `v2.2.4` → `v2.4.13`
- `pyproject-fmt` `v2.6.0` → `v2.21.1`
- `ruff-pre-commit` `v0.13.2` → `v0.15.12`

## Validation
- `pre-commit run --all-files` ✓
- `uv sync` ✓
- `uvx hatch env show --json` confirms matrix resolves to `py3.11-stable`, `py3.14-stable`, `py3.14-pre`.
- `uvx hatch test` (Python 3.14) — 13/13 passed.

## Not in this PR
- Codecov template changes (kept current setup with `${{ secrets.CODECOV_TOKEN }}`).
- `docs/conf.py` edits (file no longer exists since 388fb10).
- Agent-neutral docs (`AGENTS.md`/`CLAUDE.md`/`REVIEW_GUIDE.md`) — coming in a follow-up PR.

Closes #22, closes #23.
