### PR TITLE
docs: add agent-neutral repo guides (AGENTS.md, REVIEW_GUIDE.md)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,62 +1,7 @@
 # Copilot Instructions for slurm_sweep
 
-## Project Overview
+Canonical repo guidance lives in:
+- `AGENTS.md` — architecture, invariants, and validation commands
+- `REVIEW_GUIDE.md` — PR review workflow, risk areas, and changed-path test lookup
 
-**slurm_sweep** is a lightweight CLI tool for running hyperparameter sweeps on
-SLURM clusters using Weights & Biases (W&B). It bridges W&B sweeps with SLURM
-job arrays via [simple_slurm][], enabling efficient parallel hyperparameter
-optimization.
-
-### Domain Context
-- **SLURM**: HPC workload manager for job scheduling on clusters. Uses job
-  arrays for parallel execution.
-- **W&B Sweeps**: Hyperparameter optimization tool that tracks experiments,
-  supports grid/random/bayesian search.
-- **Workflow**: 1) Define sweep in `config.yaml`, 2) Write training script
-  (`train.py`) that logs to W&B, 3) Submit SLURM job array where each job
-  runs a W&B agent.
-
-### Key Dependencies
-- **Core**: wandb, simple-slurm, typer (CLI), numpy, session-info2
-
-## Architecture
-
-### Core Components
-1. **`src/slurm_sweep/cli.py`**: CLI commands via Typer
-   - `configure-sweep`: Register W&B sweep, generate `submit.sh` script
-   - `validate-config`: Validate YAML config file
-2. **`src/slurm_sweep/sweep_class.py`**: `SweepManager` class
-   - `register_sweep()`: Create W&B sweep via API
-   - `write_script()`: Generate SLURM submission script
-3. **`src/slurm_sweep/utils.py`**: `ConfigValidator` for YAML validation
-4. **`examples/`**: Example configs and training scripts
-
-## Project-Specific Patterns
-
-### Config File Structure (YAML)
-Three sections: `general` (project/entity/env), `slurm` (job params), `wandb`
-(sweep config). See `examples/` for templates.
-
-### CLI Usage
-```bash
-slurm-sweep validate-config config.yaml
-slurm-sweep configure-sweep config.yaml
-sbatch submit.sh
-```
-
-## Common Gotchas
-
-1. **W&B login**: Must be logged in (`wandb login`) before running `configure-sweep`
-2. **SLURM array size**: Match array range to number of parallel jobs needed (e.g., `array: "0-9"` = 10 jobs)
-3. **Agent count**: Set `count: 1` in general config to avoid multiple agents per job (recommended for SLURM)
-4. **Module loading**: Modules are space-separated in config (e.g., `modules: "stack eth_proxy"`)
-5. **Environment activation**: Mamba env must exist on compute nodes, not just login node
-6. **Training script**: Must call `wandb.init()` and log metrics via `wandb.log()`
-
-## Related Resources
-
-- **Examples**: `examples/` folder with various use cases
-- **W&B Sweeps docs**: https://docs.wandb.ai/guides/sweeps/
-- **simple_slurm**: https://github.com/amq92/simple_slurm
-
-[simple_slurm]: https://github.com/amq92/simple_slurm
+If this file conflicts with those guides, the guides win.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md — slurm_sweep
+
+`slurm_sweep` is a small CLI tool that bridges Weights & Biases sweeps with SLURM
+job arrays via [simple_slurm][]. It registers a W&B sweep from a YAML config and
+emits a `submit.sh` script that runs `wandb agent` inside a SLURM array.
+
+Key dependencies: `wandb`, `simple-slurm`, `typer`, `session-info2`.
+Python: 3.11–3.14.
+
+## Trust Order
+
+When sources disagree:
+1. PR description and changed code
+2. This file (`AGENTS.md`)
+3. `REVIEW_GUIDE.md`
+4. Tests under `tests/`
+5. Example configs and training scripts under `examples/`
+
+This file owns invariants and the where-to-find table. Review-specific workflow
+lives in `REVIEW_GUIDE.md`.
+
+## Review Guidelines
+
+For GitHub PR reviews, use `REVIEW_GUIDE.md` as the canonical review workflow and
+source of review-specific risk areas, testing checks, and documentation-impact
+checks. This file only owns the project invariants and source-of-truth map.
+
+## Where To Find What
+
+| Topic | Source of truth |
+|-------|-----------------|
+| CLI commands (`configure-sweep`, `validate-config`) | `src/slurm_sweep/cli.py` |
+| Console-script entry shim (`slurm-sweep` → `app`) | `src/slurm_sweep/main.py` |
+| Sweep registration + `submit.sh` generation | `src/slurm_sweep/sweep_class.py` (`SweepManager`) |
+| YAML config schema + validation | `src/slurm_sweep/utils.py` (`ConfigValidator`) |
+| Logger setup (`logger`) | `src/slurm_sweep/_logging.py` |
+| Public API | `src/slurm_sweep/__init__.py` — exports `SweepManager`, `logger` only |
+| Example configs and training scripts | `examples/` (`basic_config.yaml`, `simple/`, `scrna_seq_embedding/`, `spatial_embedding/`) |
+| Test fixtures | `tests/conftest.py` |
+| Contributor guide | `docs/contributing.md` |
+| PR review workflow & risk areas | `REVIEW_GUIDE.md` |
+
+## Critical Invariants
+
+### Config schema (enforced by `ConfigValidator`)
+- Three top-level blocks: `general`, `slurm`, `wandb`. Unknown blocks trigger a
+  warning and are ignored.
+- `wandb` is mandatory and must contain `program`, `method`, and `parameters`
+  (per the W&B sweep spec).
+- `general` is mandatory and must contain `entity` and `project_name`.
+- `slurm` is optional; defaults to `{}` if missing.
+
+### Generated `submit.sh` shape
+- `simple_slurm.Slurm(**slurm_parameters)` builds the `#SBATCH` header.
+- Optional `module load <modules>` (space-separated string in config).
+- Optional mamba activation: `source $HOME/.bashrc && mamba activate <env>`. The
+  env must exist on **compute** nodes, not just the login node.
+- Final command: `wandb agent [--count N] "<entity>/<project>/<sweep_id>"`.
+- `count: 1` is the recommended SLURM setting — one agent per array task.
+
+### CLI / entry point
+- `pyproject.toml` declares `scripts.slurm-sweep = "slurm_sweep.main:app"`.
+  `main.py` is a one-line re-export of `cli.app`; do not move logic into it.
+- `wandb.login()` is called inside `SweepManager.register_sweep()`, so the user
+  must already be logged in when running `configure-sweep`.
+
+### Public API
+- Only `SweepManager` and `logger` are exported from the top level. Everything
+  else (`ConfigValidator`, internal helpers) is reachable only via submodule
+  imports. Keep this surface minimal — additions require justification.
+
+### Training scripts (user-supplied)
+- Must call `wandb.init()` and read hyperparameters from `wandb.config`.
+- Metrics must be logged via `wandb.log()` for the sweep to optimize anything.
+- `examples/simple/train.py` is the canonical minimal template.
+
+## Development Commands
+
+Python 3.11 and 3.14 are the matrix endpoints (see `[tool.hatch.envs.hatch-test.matrix]`).
+
+```bash
+uv sync                             # install dev deps via dependency-groups
+uv run --group test pytest          # quick local test run
+uvx hatch test                      # run tests on the highest matrix Python
+uvx hatch test --all                # full matrix (3.11 stable, 3.14 stable, 3.14 pre)
+pre-commit run --all-files          # lint + format (ruff, biome, pyproject-fmt)
+```
+
+CLI smoke-tests (no SLURM/W&B needed for `validate-config`):
+
+```bash
+slurm-sweep validate-config examples/basic_config.yaml
+slurm-sweep configure-sweep examples/simple/config.yaml   # requires `wandb login`
+```
+
+[simple_slurm]: https://github.com/amq92/simple_slurm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# slurm_sweep Agent Entry Point
+
+@AGENTS.md
+
+Use `REVIEW_GUIDE.md` for the PR review workflow, risk areas, and changed-path
+test lookup.

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -1,0 +1,89 @@
+# slurm_sweep Review Guide
+
+This file is the canonical, agent-neutral source of truth for automated PR review in this repo.
+It is written for **agents performing PR reviews on GitHub** — use the imperative voice and be concrete.
+
+**Scope: review only.** Your job is to produce review comments and suggestions on the PR. Do **not** push commits, modify files, or apply fixes yourself. Any changes are the author's call. Flag issues, ask questions, and suggest concrete diffs in comments when helpful — but leave the decision and the edits to the user.
+
+Use `AGENTS.md` for architecture, invariants, and commands. Use this guide for review workflow, risk areas, testing checks, documentation-impact checks, and test lookup.
+
+## Review-First Workflow
+
+1. Read the PR body first when it is present.
+2. Check CI status (`gh pr checks <num>`, `gh run view <run-id> --log-failed`) and investigate any test or lint failures before commenting. Do not run the test suite locally — rely on CI.
+3. Identify changed modules and map them to matching tests (see [Changed-Path Test Lookup](#changed-path-test-lookup)).
+4. Check whether the change touches a repo invariant from `AGENTS.md`.
+5. Prioritize behavioral regressions in the generated `submit.sh`, config-schema breakage, and CLI-surface changes over style feedback.
+6. Verify that docs (human- and agent-facing) did not become stale — see [Documentation Impact](#documentation-impact).
+
+## High-Risk Areas
+
+- **Config schema (`utils.py` / `ConfigValidator`)**:
+  changes here silently break every user's YAML. New required fields, renamed keys, or removed defaults must be called out in the PR body and exercised by tests.
+- **Generated `submit.sh` (`sweep_class.py` / `SweepManager.write_script`)**:
+  module loading, mamba activation, and the final `wandb agent` line are the contract with users' SLURM clusters. Watch for changes to `--count`, shell quoting, and the default `convert=False`.
+- **CLI (`cli.py`)**:
+  Typer command and option signatures are user-facing. Renames or removed defaults are breaking changes.
+- **Entry-point shim (`main.py`)**:
+  must remain a one-line re-export of `cli.app` (the console script `slurm-sweep` resolves through it).
+- **Public API surface (`__init__.py`)**:
+  only `SweepManager` and `logger` are exported. Re-exports of internals (e.g. `ConfigValidator`) commit the project to an API; flag unnecessary additions.
+- **W&B SDK drift**:
+  `wandb.login()`, `wandb.sweep(...)` signatures and return types vary across versions. New W&B calls should be tested against at least the pinned floor.
+- **`count` semantics**:
+  `count: 1` per agent is the recommended SLURM pattern. Changes to its propagation into the agent command affect every multi-task array.
+- **Examples (`examples/`)**:
+  examples are documentation. Any config-schema, CLI, or `submit.sh` change must be reflected in the relevant example.
+
+## Changed-Path Test Lookup
+
+| Touched file | Tests to look at |
+|--------------|------------------|
+| `src/slurm_sweep/cli.py`, `src/slurm_sweep/main.py` | `tests/test_cli.py` |
+| `src/slurm_sweep/sweep_class.py` | `tests/test_sweep_manager.py` |
+| `src/slurm_sweep/utils.py` | `tests/test_config_validation.py` |
+| `src/slurm_sweep/_logging.py`, `__init__.py`, cross-cutting | `tests/test_basic.py`, `tests/conftest.py` |
+
+## Testing
+
+Apply these checks whenever the PR touches code or tests. **Read CI output rather than running tests locally.**
+
+**New code.** Confirm that new behavior is covered by tests.
+- Reuse fixtures from `tests/conftest.py` rather than creating parallel ones.
+- Prefer `pytest.mark.parametrize` over many near-identical tests.
+- Favor few meaningful tests over many redundant ones; flag low-value tests that only duplicate existing coverage.
+
+**Failing tests.** If CI is red, do not wave it through.
+- Inspect which tests fail and why (`gh pr checks <num>`, `gh run view <run-id> --log-failed`).
+- Distinguish critical regressions (config-schema, `submit.sh` shape, CLI surface) from trivial or flaky failures.
+- Surface critical failures back to the author and ask them to fix before merge.
+
+**Modified tests.** Scrutinize *how* existing tests were changed.
+- PRs that only relax thresholds, remove assertions, delete cases, or loosen `parametrize` matrices are a red flag — tests-working-around-tests defeats the purpose.
+- Require an explicit justification in the PR body for any weakened assertion; do not accept silently.
+
+## Documentation Impact
+
+A single behavioral or API change often touches docs in multiple places. Check both audiences and ask the author to update what is stale. Point to the **owning file** for each topic rather than duplicating content in your review.
+
+**Human-facing docs.**
+- Public API or CLI changes → `README.md` and `docs/contributing.md` if relevant.
+- Config-schema changes → `examples/basic_config.yaml` (the canonical commented template) and `examples/README.md`.
+- `submit.sh` shape changes → check that `examples/*/submit.sh` references in the example READMEs still match.
+
+**Agent-facing docs (repo root and `.github/`).**
+- Invariants or development commands changed → `AGENTS.md` (Critical Invariants, Development Commands).
+- Review workflow, risk areas, or testing conventions changed → `REVIEW_GUIDE.md` (this file).
+- Repo structure or top-level pointers moved → `AGENTS.md` "Where To Find What" table, `CLAUDE.md`, `.github/copilot-instructions.md`.
+
+If behavior changes but the relevant docs do not, call it out explicitly in the review and request the update.
+
+## Review Checklist
+
+- Does the change preserve the invariants in `AGENTS.md`?
+- Does CI pass, and were any failures investigated? (See [Testing](#testing).)
+- Is test coverage adequate and non-redundant, and are modified tests not simply weakened? (See [Testing](#testing).)
+- Does it alter the generated `submit.sh`, config schema, or CLI surface in a way that needs explicit mention in the PR body?
+- Is the public API surface still minimal (`SweepManager` and `logger` only at the top level)?
+- Are all affected human- and agent-facing docs updated, including examples? (See [Documentation Impact](#documentation-impact).)
+- Is the PR scope tight — no unrelated changes bundled in?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
+  "pyyaml",
+  "rich",
   # for debug logging (referenced from the issue template)
   "session-info2",
   "simple-slurm",


### PR DESCRIPTION
## Summary

Adds agent-neutral repository docs (`AGENTS.md`, `CLAUDE.md`, `REVIEW_GUIDE.md`) modeled on the structure used in `avanti`, and slims `.github/copilot-instructions.md` to a pointer. This decouples authoritative project knowledge from any single AI agent vendor and removes a few inaccuracies in the current Copilot instructions along the way.

## What changed

- **`AGENTS.md`** (new) — owns project invariants, the where-to-find table, and dev commands. Notable additions vs. the old Copilot file:
  - `main.py` is documented as the console-script entry shim (was missing before).
  - `_logging.py` and the public API surface (`SweepManager`, `logger` only) are documented.
  - Python matrix is the new 3.11 / 3.14 endpoints.
  - Dev commands updated to reflect the dependency-groups migration (`uv run --group test pytest`, `uvx hatch test`).
- **`REVIEW_GUIDE.md`** (new) — owns the PR review workflow, high-risk areas, a changed-path → test lookup table, and a review checklist.
- **`CLAUDE.md`** (new) — 4-line pointer at `@AGENTS.md`.
- **`.github/copilot-instructions.md`** — replaced with a 7-line pointer at `AGENTS.md` and `REVIEW_GUIDE.md`.

## Boundary

- `AGENTS.md` owns invariants and the source-of-truth map.
- `REVIEW_GUIDE.md` owns review-only workflow.
- No information is duplicated between the two — same pattern as `avanti`.

## Verified

- `pre-commit run --all-files` ✓
- The where-to-find table cross-checked against actual contents of `src/slurm_sweep/` (cli.py, main.py, sweep_class.py, utils.py, _logging.py, __init__.py).
- Examples folder content verified (`simple/`, `scrna_seq_embedding/`, `spatial_embedding/`, `basic_config.yaml`) — no stale references.

## Not in this PR

- Touching `src/` or examples (this is a docs-only PR).
- Audit follow-ups (e.g., `rich` is imported in `_logging.py` but only available transitively via `wandb`/`typer`) — flagged for a future change, not addressed here.
